### PR TITLE
Remove Sidebar_divs.js file

### DIFF
--- a/app/Css/Graph.hs
+++ b/app/Css/Graph.hs
@@ -271,6 +271,8 @@ graphContainer = do
 
 sidebarCSS :: Css
 sidebarCSS = do
+    ".hidden" ? do
+        display none
     "#fce" ? do
         height (px 40)
         width (pct 100)
@@ -280,7 +282,6 @@ sidebarCSS = do
         height (px 40)
         float floatLeft
         backgroundColor purple7
-        display none
         textAlign $ alignSide sideCenter
         paddingLeft (px 15)
         paddingTop (px 5)
@@ -290,7 +291,6 @@ sidebarCSS = do
         float floatLeft
         width (pct 47)
         height (px 40)
-        display none
         border solid (px 1) black
         cursor pointer
         ":hover" & do
@@ -364,7 +364,6 @@ sidebarCSS = do
         marginTop (px 25)
         marginLeft (px 25)
         height (pct 86)
-        display none
         overflowY scroll
     ".focus" ? do
         display block

--- a/js/components/graph/Sidebar.js
+++ b/js/components/graph/Sidebar.js
@@ -9,10 +9,12 @@ export default class Sidebar extends React.Component {
       hidden: true,
       focusHidden: true,
       focusActive: false,
+      graphHidden: true,
       graphActive: false,
       sidebarFlipped: false,
     }
     this.toggleSidebar = this.toggleSidebar.bind(this);
+    this.showFocuses = this.showFocuses.bind(this);
   }
 
 
@@ -44,6 +46,7 @@ export default class Sidebar extends React.Component {
         hidden: true,
         focusHidden: true,
         focusActive: false,
+        graphHidden: true,
         graphActive: true,
         sidebarFlipped: false,
       })
@@ -65,9 +68,19 @@ export default class Sidebar extends React.Component {
     }
   }
 
+  showFocuses() {
+    this.setState({
+      focusHidden: false,
+      focusActive: true,
+      graphHidden: true,
+      graphActive: false,
+    });
+  }
+
   render() {
     const hiddenClass = this.state.hidden ? "hidden" : "";
-    const activeClass = this.state.active ? "active" : "";
+    const focusActiveClass = this.state.focusActive ? "active" : "";
+    const graphActiveClass = this.state.graphActive ? "active" : "";
     const focusClass = this.state.focusHidden ? "hidden" : "";
     const flippedClass = this.state.sidebarFlipped ? "flip" : "";
     return (
@@ -79,10 +92,10 @@ export default class Sidebar extends React.Component {
           </div>
           <nav id="sidebar-nav">
             <ul>
-              <li id="graphs-nav" className={activeClass}>
+              <li id="graphs-nav" className={graphActiveClass}>
                 <a href="">Graphs</a>
               </li>
-              <li id="focuses-nav" className={activeClass}>
+              <li id="focuses-nav" className={focusActiveClass} onClick={this.showFocuses}>
                 <a href="">Focuses</a>
               </li>
             </ul>

--- a/js/components/graph/Sidebar.js
+++ b/js/components/graph/Sidebar.js
@@ -2,6 +2,20 @@ import React from "react";
 import Focus from "./Focus";
 
 export default class Sidebar extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      toggled: false,
+      hidden: true,
+      focusHidden: true,
+      focusActive: false,
+      graphActive: false,
+      sidebarFlipped: false,
+    }
+    this.toggleSidebar = this.toggleSidebar.bind(this);
+  }
+
+
   getFocusData() {
     const computerScienceFocusData = [
       ["sci", "Scientific Computing"],
@@ -23,33 +37,68 @@ export default class Sidebar extends React.Component {
     return focusComponents;
   }
 
+  toggleSidebar(location) {
+    if (this.state.toggled) {
+      this.setState({
+        toggled: false,
+        hidden: true,
+        focusHidden: true,
+        focusActive: false,
+        graphActive: true,
+        sidebarFlipped: false,
+      })
+      $("#sidebar").animate({ width: "40px" }, "fast", undefined, function() {
+        $("#sidebar-icon").removeClass("flip");
+      });
+    } else if (!this.state.toggled && location === "button") {
+      $("#sidebar").animate({ width: "400px" }, "fast", undefined, function() {
+        $("#sidebar-icon").addClass("flip");
+      });
+
+      this.setState({
+        toggled: true,
+        hidden: false,
+        graphActive: true,
+        sidebarFlipped: true,
+      })
+      $("#graphs-nav").addClass("active");
+    }
+  }
+
   render() {
+    const hiddenClass = this.state.hidden ? "hidden" : "";
+    const activeClass = this.state.active ? "active" : "";
+    const focusClass = this.state.focusHidden ? "hidden" : "";
+    const flippedClass = this.state.sidebarFlipped ? "flip" : "";
     return (
       <div>
         <div id="sidebar">
-          <div id="fce">
-            <div id="fcecount">FCE Count: 0.0</div>
-            <button id="reset">Reset Graph</button>
+          <div id="fce" className={hiddenClass}>
+            <div id="fcecount" className={hiddenClass}>FCE Count: 0.0</div>
+            <button id="reset" className={hiddenClass}>Reset Graph</button>
           </div>
           <nav id="sidebar-nav">
             <ul>
-              <li id="graphs-nav">
+              <li id="graphs-nav" className={activeClass}>
                 <a href="">Graphs</a>
               </li>
-              <li id="focuses-nav">
+              <li id="focuses-nav" className={activeClass}>
                 <a href="">Focuses</a>
               </li>
             </ul>
           </nav>
 
-          <div id="focuses">
+          <div id="focuses" className={focusClass}>
             {this.getFocusData()}
           </div>
-          <div id="graphs"></div>
+          <div id="graphs" className={hiddenClass}></div>
         </div>
         
-        <div id="sidebar-button">
-          <img id="sidebar-icon" src="static/res/ico/sidebar.png"></img>
+        <div id="sidebar-button" onClick={() => this.toggleSidebar("button")}>
+          <img id="sidebar-icon"
+           className={flippedClass} 
+           src="static/res/ico/sidebar.png"
+          />
         </div>
       </div>
     )

--- a/js/components/graph/sidebar/sidebar_divs.js
+++ b/js/components/graph/sidebar/sidebar_divs.js
@@ -3,9 +3,9 @@ var toggled = false;
 export function activateSidebar() {
   "use strict";
 
-  $("#sidebar-button").click(function() {
-    toggleSidebar("button");
-  });
+  // $("#sidebar-button").click(function() {
+  //   toggleSidebar("button");
+  // });
 
   $("#focuses-nav").click(function(e) {
     e.preventDefault();

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,15 +5,57 @@
 
 packages:
 - completed:
-    hackage: happstack-server-7.6.1@sha256:639af7840c897a3a0273bb183149990cbf18127077a025c3004606e27cbe56a0,6028
+    hackage: binary-0.8.7.0@sha256:ae3e6cca723ac55c54bbb3fa771bcf18142bc727afd57818e66d6ee6c8044f12,7705
     pantry-tree:
-      size: 2978
-      sha256: 9a9d737893f4b48b654ed164d385f4d98da1a01593a0af36ea6837dc31817fcb
+      size: 1976
+      sha256: 35e44b6d3ccf0d56fc5407dc3f0895e74696a66da189afbd65973c95743f5e25
   original:
-    hackage: happstack-server-7.6.1
+    hackage: binary-0.8.7.0
+- completed:
+    hackage: HaTeX-3.20.0.0@sha256:734e4a017c1c18c332a67be7139b1099a805ddbeeaae11fade723076e4077805,5339
+    pantry-tree:
+      size: 6794
+      sha256: 7461275e8a5df42383421674c0781fc9afc6f0ffd177db959afac76cb19065f9
+  original:
+    hackage: HaTeX-3.20.0.0
+- completed:
+    hackage: containers-0.5.11.0@sha256:28ad7337057442f75bc689315ab4ec7bdf5e6b2c39668f306672cecd82c02798,16685
+    pantry-tree:
+      size: 4849
+      sha256: faa4e75922a28f7cfe9920c1d7ab3866b792cefcd29bf79f54cfe3b6b5f57cbf
+  original:
+    hackage: containers-0.5.11.0
+- completed:
+    hackage: graphviz-2999.20.0.3@sha256:cde383c356bc41136ed53cd27e0800f46dbd2185600dd0de18d66d5c49739d94,7677
+    pantry-tree:
+      size: 4322
+      sha256: f7d9f7e161d68a5783d915358c28a95a2b8c94f3e302325fa604b91e8d2295c8
+  original:
+    hackage: graphviz-2999.20.0.3
+- completed:
+    hackage: happstack-server-7.5.1.3@sha256:5cfaffa15fe97262d3856196add3e1f92a236e2c5e0afa5ec21ed36887513996,6449
+    pantry-tree:
+      size: 3201
+      sha256: 819ad7fdcf9e97efd54c4046731b428b2a3154ffad23f221ec9a54c436870218
+  original:
+    hackage: happstack-server-7.5.1.3
+- completed:
+    hackage: sendfile-0.7.9@sha256:534718a7fd1b36878594c1307ef998a683a9f16807a2769a34b905b11a3b289f,2230
+    pantry-tree:
+      size: 926
+      sha256: 5ff40f7118a81ba6f25ec5750f2ab7cea37ab6f3a3e79a814545a058eb44f861
+  original:
+    hackage: sendfile-0.7.9
+- completed:
+    hackage: wl-pprint-extras-3.5.0.5@sha256:fcccabbab059e15ad3816998dc1f1f750afb480164bd116b147cc8a35a5da0b8,1446
+    pantry-tree:
+      size: 423
+      sha256: 4751be77e93e98ca5c6b9c8daa5131ed98fdc866fb3ee77356b1f7711f6cae18
+  original:
+    hackage: wl-pprint-extras-3.5.0.5
 snapshots:
 - completed:
-    size: 524996
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/14/27.yaml
-    sha256: 7ea31a280c56bf36ff591a7397cc384d0dff622e7f9e4225b47d8980f019a0f0
-  original: lts-14.27
+    size: 498155
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/13/19.yaml
+    sha256: b9367a80d4393d02e58a46b8a9fdfbd7bc19f59c0c2bbf90034ba15cf52cf213
+  original: lts-13.19


### PR DESCRIPTION
We want to remove all the functions that utilize jQuery in `sidebar_divs.js` and move them into their respective components. 

## Note:
* A lot of the jQuery functions were used to display individual sidebar components (ids originally) by calling jQuery `show` and `hide` functions. The equivalent in React is applying CSS to either set `display = None` or leave the className blank.
* I am currently asking David what to do with the jQuery `animate` function as there isn't a simple equivalent in React.
* The Haskell CSS was updated so `stack exec courseography css` needs to be run for CSS to show up properly.

## TODO:
 * [ ] `activateSidebar`
 * [x] `resetDivs`
 * [x] `toggleSidebar`
 * [ ] `createGraphsButtons`
 * [ ] `changeFocusEnable`